### PR TITLE
Document build instructions and more precise set of dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: cpp
 
+dist: xenial
+
 os:
   - linux
   - osx
@@ -8,31 +10,55 @@ compiler:
   - clang
   - gcc
 
+# We have to update Homebrew to work around an issue installing any packages.
+# See: https://travis-ci.community/t/issue-brew-formula-installation-fails-due-to-being-outdated/3872
 addons:
   apt:
     packages:
       - libeigen3-dev
   homebrew:
+    update: true
     packages:
       - eigen
+      - sundials
 
+# Since Homebrew is updated on each build, we'll cache the corresponding package
+# directories:
+cache:
+  directories:
+    - $HOME/Library/Caches/Homebrew
+
+# Since the Homebrew files are now cached, the cache itself should be managed.
+# Before saving the cache, we'll make sure to remove any outdated packages:
+before_cache:
+  - if [ "${TRAVIS_OS_NAME}" == "osx" ] ; then 
+      brew cleanup ;
+    fi
+
+# Sundials and Boost only need to be built from source on Linux
 install:
-  - cd ${TRAVIS_BUILD_DIR}
-  - curl https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.gz -L -o boost_1_69_0.tar.gz
-  - tar xzf boost_1_69_0.tar.gz
-  - cd boost_1_69_0
-  - ./bootstrap.sh --prefix=${TRAVIS_BUILD_DIR}/usr
-  - travis_wait ./b2 -d0 -q --with-math --with-test --with-system install
-  - cd ${TRAVIS_BUILD_DIR}
-  - wget https://computation.llnl.gov/projects/sundials/download/cvodes-4.1.0.tar.gz
-  - tar xzf cvodes-4.1.0.tar.gz
-  - cd cvodes-4.1.0
-  - mkdir build
-  - cd build
-  - cmake -DCMAKE_INSTALL_PREFIX:PATH=${TRAVIS_BUILD_DIR}/usr .. 
-  - make
-  - make install
+  - if [ "${TRAVIS_OS_NAME}" == "linux" ] ; then 
+      cd ${TRAVIS_BUILD_DIR} ; 
+      curl https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.gz -L -o boost_1_69_0.tar.gz ; 
+      tar xzf boost_1_69_0.tar.gz ; 
+      cd boost_1_69_0 ; 
+      ./bootstrap.sh --prefix=${TRAVIS_BUILD_DIR}/usr ; 
+      travis_wait ./b2 -d0 -q --with-math --with-test --with-system install ;
+      cd ${TRAVIS_BUILD_DIR} ;
+      wget https://computation.llnl.gov/projects/sundials/download/cvodes-4.1.0.tar.gz ;
+      tar xzf cvodes-4.1.0.tar.gz ;
+      mkdir -p cvodes-4.1.0/build ;
+      cd cvodes-4.1.0/build ;
+      cmake -DCMAKE_INSTALL_PREFIX:PATH=${TRAVIS_BUILD_DIR}/usr .. ;
+      make ;
+      make install ;
+    fi
 script:
   - cd ${TRAVIS_BUILD_DIR}
-  - make all CXXFLAGS_EXTRA="-I${TRAVIS_BUILD_DIR}/usr/include"
+  - if [ "${TRAVIS_OS_NAME}" == "linux" ] ; then
+      make all CXXFLAGS_EXTRA="-I${TRAVIS_BUILD_DIR}/usr/include" ;
+    fi
+  - if [ "${TRAVIS_OS_NAME}" == "osx" ] ; then
+      make all CXXFLAGS_EXTRA="-I/usr/local/include" ;
+    fi
   - make tests

--- a/README.md
+++ b/README.md
@@ -8,67 +8,91 @@ This is a software package developed to pursue numerical calculations reported
 in the paper “Identification of parameters in systems biology” by 
 Ugur G. Abdulla & Roby Poteau, submitted to Mathematical Biosciences.
 
-Professor Ugur G. Abdulla,Ph.D.,Dr.Sci.  
-Department of Mathematical Sciences  
-Florida Institute of Technology  
-Melbourne, FL  
-Email:abdulla@fit.edu
+> Professor Ugur G. Abdulla,Ph.D.,Dr.Sci.  
+> Department of Mathematical Sciences  
+> Florida Institute of Technology  
+> Melbourne, FL  
+> Email: [abdulla@fit.edu](abdulla@fit.edu)
 
-Roby Poteau  
-Ph.D. Student in Operations Research  
-Department of Mathematical Sciences  
-Florida Institute of Technology  
-Email:rpoteau2010@my.fit.edu
+> Roby Poteau  
+> Ph.D. Student in Operations Research  
+> Department of Mathematical Sciences  
+> Florida Institute of Technology  
+> Email: [rpoteau2010@my.fit.edu](rpoteau2010@my.fit.edu)
 
 
-### Prerequisites
+## Prerequisites
 
-I use [GNU Make](https://www.gnu.org/software/make/) which is bundled in build-essential package
+* [GNU Make](https://www.gnu.org/software/make/)
 
-```
-sudo apt-get install build-essential
-```
+* [Eigen 3](http://eigen.tuxfamily.org/index.php?title=Main_Page)
 
-[Eigen 3.3.7](http://eigen.tuxfamily.org/index.php?title=Main_Page)
+* [Boost 1.65+](https://www.boost.org)
 
-```
-git clone https://github.com/eigenteam/eigen-git-mirror.git eigen_source
-mkdir eigen_build
-cd eigen_build
-cmake ../eigen_source
-make install            # may need sudo to run this
+### OSX Build Instructions
+
+The version of Eigen and Boost installed by [Homebrew](https://brew.sh/) is sufficient to build qlopt on an OSX platform:
+
+```shell
+brew install eigen boost
 ```
 
-[Boost 1.69.0](https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.gz)
+You'll need the command-line build tools available as well, though those are a Homebrew build requirement.
 
+### Ubuntu/Debian
+If you're running a new enough Debian/Ubuntu system, you can install those libraries through your package manager.
+The versions available on Ubuntu Bionic (18.04 LTS) or Debian Buster are known to work, and can be installed by
+
+```shell
+sudo apt-get install libeigen3-dev libboost-math-dev build-essential
 ```
+
+On Ubuntu Xenial or Debian Stretch, Boost is too old, so you'll need to build it from source (see below) and on distributions older than that, both Boost and Eigen must be built from source.
+You'll need `build-essential` no matter which version of Debian/Ubuntu you're using.
+
+### Build Dependencies from Source
+
+To build [Eigen 3.3.7](https://github.com/eigenteam/eigen-git-mirror) from source local to your project, run
+
+```shell
+git clone https://github.com/eigenteam/eigen-git-mirror.git
+mkdir -p eigen-git-mirror/build && cd eigen-git-mirror/build
+git checkout tags/3.3.7 -b eigen-3.3.7
+cmake -DCMAKE_INSTALL_PREFIX=/path/to/project-root/usr ..
+make install
+```
+
+*Note*: Modify the prefix above to point to your project root, and follow the modified build instructions below.
+
+To install [Boost 1.69.0](https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.gz) local to your project, run
+
+```shell
 wget https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.gz
 tar xf boost_1_69_0.tar.gz
 cd boost_1_69_0
-sudo ./bootstrap.sh
-sudo ./b2 install
+./bootstrap.sh --prefix=/path/to/project-root/usr
+./b2 -d0 -q --with-math --with-test --with-system install
 ```
 
-### Installation
-Make sure Eigen is installed. Download or clone the repository into a 
-folder and run `make` command in the project's root directory 
-(you can also use `sudo make` if the command doesn't work).
+*Note*: Modify the prefix above to point to your project root.
 
-### Usage
-When you run `make` it will create executables in the bin folder from source files 
-in the examples folder. You can use them as a guide to apply this code to your
+If you install Boost or Eigen this way, compile Qlopt with
+
+```shell
+make all CXXFLAGS_EXTRA="-I`pwd`/usr/include"
+```
+
+### Installation and Usage
+
+Download or clone the repository into a folder and run `make` command in the project's root directory.
+
+When you run `make` it will create executables in the `bin` folder from source files 
+in the `examples` folder. You can use them as a guide to apply this code to your
 own examples.
-When you create your own examples, just drop it into the examples
-folder and run the make file in the root directory this will create an
-executable which you can run from the bin folder. 
 
-To run the executable, you need libparamid in your system's library
-```
-# At QLOPT root directory
-cd build
-sudo cp libparamid.* /usr/lib/
-sudo ldconfig
-```
+When you create your own example, just drop it into the examples
+folder and run the `make` in the root directory; this will create an
+executable which you can run from the `bin` folder. 
 
 ## Questions
 If you have any questions feel free to e-mail us at:
@@ -76,6 +100,3 @@ abdulla@fit.edu; rpoteau2010@my.fit.edu
 
 ## License
 This project is licensed under the GNU General Public License v3.0 License - see the [LICENSE.md](LICENSE.md) file for details
-
-## Notes
-I developed in a debian Linux environment.


### PR DESCRIPTION
Also, build on Ubuntu Xenial (otherwise Eigen is too old) and remove Boost build for OSX. This means that all implemented tests pass (!) and the build is faster.

@robypoteau If you turn on Travis for this repository, you'll get pass/fail information on PRs from now on (See issue #6)